### PR TITLE
feat: Support data argument for GCS bucket seeding

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,4 +43,4 @@ pytest_gcs = "pytest_gcs.plugin"
 
 
 [project.optional-dependencies]
-test = ["mypy", "pytest-cov", "pydocstyle"]
+test = ["mypy", "pytest-cov", "pydocstyle", "isort"]

--- a/pytest_gcs/config.py
+++ b/pytest_gcs/config.py
@@ -12,6 +12,7 @@ class GcsConfigType(TypedDict):
     port: Optional[int]
     host: str
     filesystemroot: str
+    data: str
     corsheaders: List[str]
     externalurl: str
     loglevel: str
@@ -32,6 +33,7 @@ def get_config(request: FixtureRequest) -> GcsConfigType:
         "port": int(port) if port else None,
         "host": get_conf_option("host"),
         "filesystemroot": get_conf_option("filesystemroot"),
+        "data": get_conf_option("data"),
         "corsheaders": get_conf_option("corsheaders"),
         "externalurl": get_conf_option("externalurl"),
         "loglevel": get_conf_option("loglevel"),

--- a/pytest_gcs/executor/process.py
+++ b/pytest_gcs/executor/process.py
@@ -2,6 +2,7 @@
 
 Starts a local GCS server using the targeted configuration.
 """
+
 from pathlib import Path
 from typing import List, Optional
 
@@ -17,6 +18,7 @@ class GCSExecutor(HTTPExecutor):
         host: str,
         port: int,
         filesystemroot: Path,
+        data: Optional[Path] = None,
         corsheaders: Optional[List[str]] = None,
         externalurl: Optional[str] = None,
         loglevel: Optional[str] = None,
@@ -45,6 +47,9 @@ class GCSExecutor(HTTPExecutor):
             "-filesystem-root",
             str(filesystemroot),
         ]
+
+        if data:
+            command.extend(["-data", str(data)])
 
         if corsheaders:
             command.extend(["-cors-headers", ",".join(corsheaders)])

--- a/pytest_gcs/factories/proc.py
+++ b/pytest_gcs/factories/proc.py
@@ -1,4 +1,5 @@
 """GCS process factory."""
+
 from pathlib import Path
 from typing import Callable, Generator, List, Optional
 
@@ -16,6 +17,8 @@ def gcs_proc(
     host: Optional[str] = None,
     port: Optional[int] = None,
     filesystemroot: Optional[Path] = None,
+    data: Optional[str] = None,
+    data_fixture_name: Optional[str] = None,
     corsheaders: Optional[List[str]] = None,
     externalurl: Optional[str] = None,
     loglevel: Optional[str] = None,
@@ -24,7 +27,8 @@ def gcs_proc(
 
     @pytest.fixture(scope="session")
     def gcs_proc_fixture(
-        request: FixtureRequest, tmp_path_factory: TempPathFactory
+        request: FixtureRequest,
+        tmp_path_factory: TempPathFactory,
     ) -> Generator[GCSExecutor, None, None]:
         """Fixture for pytest-gcs.
 
@@ -59,11 +63,19 @@ def gcs_proc(
         )
         assert gcs_port, "Unable to find a port available."
 
+        if data_fixture_name:
+            data_path = request.getfixturevalue(data_fixture_name)
+        elif data:
+            data_path = Path(data)
+        else:
+            data_path = config["data"]
+
         gcs_executor = GCSExecutor(
             executable=Path(gcs_exec),
             port=gcs_port,
             host=host or config["host"],
             filesystemroot=_filesystemroot,
+            data=data_path,
             corsheaders=corsheaders or config["corsheaders"],
             externalurl=externalurl or config["externalurl"],
             loglevel=loglevel or config["loglevel"],

--- a/pytest_gcs/plugin.py
+++ b/pytest_gcs/plugin.py
@@ -1,4 +1,5 @@
 """pytest-gcs plugin declaration."""
+
 from shutil import which
 
 from pytest import Parser
@@ -10,6 +11,7 @@ _HELP_EXEC = "Exec file to target."
 _HELP_HOST = "Host to run GCS service on."
 _HELP_PORT = "Port to run GCS service on."
 _HELP_FILESYSTEMROOT = "File system path buckets will be stored/created at."
+_HELP_DATA = "Directory path to load data from"
 _HELP_CORSHEADERS = "Comma separated list of headers to add to the CORS allowlist."
 _HELP_EXTERNALURL = (
     "Optional external URL, returned in the Location header for uploads."
@@ -30,6 +32,7 @@ def pytest_addoption(parser: Parser) -> None:
     parser.addini(name="gcs_port", help=_HELP_PORT)
     parser.addini(name="gcs_filesystemroot", help=_HELP_FILESYSTEMROOT)
     parser.addini(name="gcs_corsheaders", help=_HELP_CORSHEADERS)
+    parser.addini(name="gcs_data", help=_HELP_DATA)
     parser.addini(name="gcs_externalurl", help=_HELP_EXTERNALURL)
     parser.addini(name="gcs_loglevel", help=_HELP_LOGLEVEL)
 
@@ -43,6 +46,12 @@ def pytest_addoption(parser: Parser) -> None:
         action="store",
         dest="gcs_filesystemroot",
         help=_HELP_FILESYSTEMROOT,
+    )
+    parser.addoption(
+        "--gcs-data",
+        action="store",
+        dest="gcs_data",
+        help=_HELP_DATA,
     )
     parser.addoption(
         "--gcs-corsheaders",

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,10 @@
 """Tests main conftest file."""
 
 import warnings
+from pathlib import Path
+from typing import Generator
+
+import pytest
 
 # import pytest_gcs.factories.noproc
 import pytest_gcs.factories.client
@@ -20,3 +24,20 @@ gcslocal1 = pytest_gcs.factories.client.gcslocal("gcs_proc1")
 
 gcs_proc2 = pytest_gcs.factories.proc.gcs_proc()
 gcslocal2 = pytest_gcs.factories.client.gcslocal("gcs_proc2")
+
+
+@pytest.fixture(scope="session")
+def seeded_data(
+    tmp_path_factory: pytest.TempPathFactory,
+) -> Generator[Path, None, None]:
+    """Create seeded data."""
+    tmp_path = tmp_path_factory.mktemp("pytest-gcs-seeded")
+    bucket_dir = tmp_path / "bucket"
+    bucket_dir.mkdir()
+    bucket_file = bucket_dir / "test"
+    bucket_file.touch()
+    yield tmp_path
+
+
+gcs_proc_seeded = pytest_gcs.factories.proc.gcs_proc(data_fixture_name="seeded_data")
+gcslocal_seeded = pytest_gcs.factories.client.gcslocal("gcs_proc_seeded")

--- a/tests/test_gcs.py
+++ b/tests/test_gcs.py
@@ -1,4 +1,5 @@
 """General plugin tests."""
+
 import pytest
 from google.cloud import storage
 
@@ -42,6 +43,18 @@ def test_gcs_write_read_files(gcs_proc: GCSExecutor, gcslocal: storage.Client) -
     blob.upload_from_string(test_string)
 
     assert bucket.get_blob(test_file).download_as_bytes().decode() == test_string
+
+
+def test_gcs_data_seed(gcslocal_seeded: storage.Client) -> None:
+    """Test data seeding."""
+    bucket = gcslocal_seeded.bucket("bucket")
+
+    assert bucket.exists()
+
+    blobs = [blob.name for blob in bucket.list_blobs()]
+
+    assert len(blobs) == 1
+    assert blobs[0] == "test"
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
Adds `data` as a config and an argument to populate the faked GCS service from a path as supported by `fake-gcs-server`
Also adds `data_fixture_name` optional argument to the `gcs_proc` factory in order to seed the fake with data generated in fixtures (no other method would support data paths derived from `tmp_path` and `tmp_path_factory` as fixtures can not be directly called)
Example added in tests